### PR TITLE
feat(lifecycle): add timeouts and health checks

### DIFF
--- a/lifecycle/README.md
+++ b/lifecycle/README.md
@@ -18,12 +18,16 @@ mgr, err := lifecycle.NewManager(
     lifecycle.WithService("settings", settingsService, lifecycle.DependsOn("database")),
     lifecycle.WithService("storage", storageService, lifecycle.DependsOn("database")),
     lifecycle.WithService("updates", updateService, lifecycle.DependsOn("settings")),
-    lifecycle.WithEmitter(emitter), // optional
+    lifecycle.WithEmitter(emitter),            // optional
+    lifecycle.WithTimeout(10 * time.Second),   // optional global timeout
 )
 // err if cyclic or missing dependencies
 
 // Start all services in dependency order.
 err = mgr.Startup(ctx)
+
+// Check health of running services.
+health := mgr.Health() // []ServiceHealth
 
 // Shut down in reverse order (collects all errors).
 err = mgr.Shutdown()
@@ -63,12 +67,14 @@ func (a *App) ServiceShutdown() error {
 |--------|-------------|
 | `WithService(name, svc, ...ServiceOption)` | Register a named service |
 | `WithEmitter(emitter)` | Set event emitter for lifecycle events |
+| `WithTimeout(d)` | Global timeout for startup/shutdown of each service |
 
 ### Service options
 
 | Option | Description |
 |--------|-------------|
 | `DependsOn(names...)` | Declare dependencies that must start first |
+| `WithServiceTimeout(d)` | Per-service timeout override (takes precedence over global) |
 
 ## Behavior
 
@@ -76,6 +82,8 @@ func (a *App) ServiceShutdown() error {
 - **Partial failure rollback** — if service N fails to start, services 1..N-1 are shut down in reverse order.
 - **All-errors shutdown** — shutdown continues through errors, collecting them all via `errors.Join`.
 - **Order** — `mgr.Order()` returns the resolved startup order for inspection.
+- **Timeouts** — global and per-service timeouts for startup/shutdown. Startup timeouts trigger rollback; shutdown timeouts are collected but don't stop other services from shutting down.
+- **Health checks** — services implementing `HealthChecker` report their status via `mgr.Health()`. Non-implementing services default to healthy.
 
 ## Events
 
@@ -85,6 +93,24 @@ func (a *App) ServiceShutdown() error {
 | `lifecycle:stopped` | `ServiceStoppedPayload{Name}` | Service stopped successfully |
 | `lifecycle:error` | `ErrorPayload{Name, Message, Code}` | Service failed to start or stop |
 | `lifecycle:rollback` | `RollbackPayload{FailedService, RollingBack, RollbackErrors}` | Partial failure triggered rollback |
+| `lifecycle:timeout` | `TimeoutPayload{Name, Phase, Timeout}` | Service startup or shutdown timed out |
+
+## Health checks
+
+Services can optionally implement `HealthChecker` to report their status:
+
+```go
+type MyService struct{ /* ... */ }
+
+func (s *MyService) Health() lifecycle.HealthStatus {
+    if s.isConnected() {
+        return lifecycle.StatusHealthy
+    }
+    return lifecycle.StatusDegraded
+}
+```
+
+Call `mgr.Health()` to get a `[]ServiceHealth` slice with each service's name and status (`healthy`, `degraded`, or `unhealthy`). Services that don't implement `HealthChecker` default to `healthy`.
 
 ## Error codes
 
@@ -94,3 +120,4 @@ func (a *App) ServiceShutdown() error {
 | `lifecycle_missing_dependency` | Service configuration error: a required dependency is missing. |
 | `lifecycle_startup` | Failed to start a required service. Please try restarting the application. |
 | `lifecycle_shutdown` | An error occurred while shutting down. Some resources may not have been cleaned up. |
+| `lifecycle_timeout` | A service took too long to respond. Please try restarting the application. |

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"time"
 
 	"github.com/jrschumacher/wails-kit/errors"
 	"github.com/jrschumacher/wails-kit/events"
@@ -20,6 +21,7 @@ const (
 	ErrMissingDep       errors.Code = "lifecycle_missing_dependency"
 	ErrStartup          errors.Code = "lifecycle_startup"
 	ErrShutdown         errors.Code = "lifecycle_shutdown"
+	ErrTimeout          errors.Code = "lifecycle_timeout"
 )
 
 func init() {
@@ -28,6 +30,7 @@ func init() {
 		ErrMissingDep:       "Service configuration error: a required dependency is missing.",
 		ErrStartup:          "Failed to start a required service. Please try restarting the application.",
 		ErrShutdown:         "An error occurred while shutting down. Some resources may not have been cleaned up.",
+		ErrTimeout:          "A service took too long to respond. Please try restarting the application.",
 	})
 }
 
@@ -37,6 +40,7 @@ const (
 	EventStopped  = "lifecycle:stopped"
 	EventError    = "lifecycle:error"
 	EventRollback = "lifecycle:rollback"
+	EventTimeout  = "lifecycle:timeout"
 )
 
 // ServiceStartedPayload is emitted when a service starts successfully.
@@ -63,10 +67,38 @@ type RollbackPayload struct {
 	RollbackErrors   []string `json:"rollbackErrors,omitempty"`
 }
 
+// HealthStatus represents the health state of a service.
+type HealthStatus string
+
+const (
+	StatusHealthy   HealthStatus = "healthy"
+	StatusDegraded  HealthStatus = "degraded"
+	StatusUnhealthy HealthStatus = "unhealthy"
+)
+
+// TimeoutPayload is emitted when a service operation times out.
+type TimeoutPayload struct {
+	Name      string `json:"name"`
+	Phase     string `json:"phase"` // "startup" or "shutdown"
+	Timeout   string `json:"timeout"`
+}
+
+// ServiceHealth reports the health of a single service.
+type ServiceHealth struct {
+	Name   string       `json:"name"`
+	Status HealthStatus `json:"status"`
+}
+
 // Service is the interface that managed services must implement.
 type Service interface {
 	OnStartup(ctx context.Context) error
 	OnShutdown() error
+}
+
+// HealthChecker is an optional interface that services can implement
+// to report their health status.
+type HealthChecker interface {
+	Health() HealthStatus
 }
 
 // entry holds a registered service and its dependency metadata.
@@ -74,6 +106,7 @@ type entry struct {
 	name    string
 	service Service
 	deps    []string
+	timeout time.Duration // per-service timeout override; 0 means use global
 }
 
 // Manager manages ordered startup and shutdown of services.
@@ -82,6 +115,7 @@ type Manager struct {
 	order   []string // topologically sorted service names
 	started []string // services that have been started (in start order)
 	emitter *events.Emitter
+	timeout time.Duration // global timeout; 0 means no timeout
 }
 
 // ManagerOption configures a Manager.
@@ -95,6 +129,13 @@ type ServiceOption func(*entry)
 func DependsOn(names ...string) ServiceOption {
 	return func(e *entry) {
 		e.deps = append(e.deps, names...)
+	}
+}
+
+// WithServiceTimeout sets a per-service timeout that overrides the global timeout.
+func WithServiceTimeout(d time.Duration) ServiceOption {
+	return func(e *entry) {
+		e.timeout = d
 	}
 }
 
@@ -113,6 +154,14 @@ func WithService(name string, svc Service, opts ...ServiceOption) ManagerOption 
 func WithEmitter(emitter *events.Emitter) ManagerOption {
 	return func(m *Manager) {
 		m.emitter = emitter
+	}
+}
+
+// WithTimeout sets a global timeout for service startup and shutdown operations.
+// Individual services can override this with WithServiceTimeout.
+func WithTimeout(d time.Duration) ManagerOption {
+	return func(m *Manager) {
+		m.timeout = d
 	}
 }
 
@@ -149,7 +198,7 @@ func (m *Manager) Startup(ctx context.Context) error {
 
 	for _, name := range m.order {
 		e := byName[name]
-		if err := e.service.OnStartup(ctx); err != nil {
+		if err := m.startService(ctx, e); err != nil {
 			startErr := errors.Wrap(ErrStartup, fmt.Sprintf("service %q failed to start", name), err).
 				WithField("service", name)
 
@@ -185,7 +234,7 @@ func (m *Manager) Shutdown() error {
 	for i := len(m.started) - 1; i >= 0; i-- {
 		name := m.started[i]
 		e := byName[name]
-		if err := e.service.OnShutdown(); err != nil {
+		if err := m.stopService(e); err != nil {
 			shutErr := errors.Wrap(ErrShutdown, fmt.Sprintf("service %q failed to shut down", name), err).
 				WithField("service", name)
 
@@ -207,6 +256,91 @@ func (m *Manager) Shutdown() error {
 		return stderrors.Join(errs...)
 	}
 	return nil
+}
+
+// Health returns the health status of all started services. Services that
+// implement HealthChecker report their own status; others are reported as healthy.
+func (m *Manager) Health() []ServiceHealth {
+	byName := m.entryMap()
+	result := make([]ServiceHealth, 0, len(m.started))
+
+	for _, name := range m.started {
+		e := byName[name]
+		status := StatusHealthy
+		if hc, ok := e.service.(HealthChecker); ok {
+			status = hc.Health()
+		}
+		result = append(result, ServiceHealth{Name: name, Status: status})
+	}
+
+	return result
+}
+
+// serviceTimeout returns the effective timeout for a service entry.
+func (m *Manager) serviceTimeout(e *entry) time.Duration {
+	if e.timeout > 0 {
+		return e.timeout
+	}
+	return m.timeout
+}
+
+// startService starts a single service, applying a timeout if configured.
+func (m *Manager) startService(ctx context.Context, e *entry) error {
+	timeout := m.serviceTimeout(e)
+	if timeout <= 0 {
+		return e.service.OnStartup(ctx)
+	}
+
+	startCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- e.service.OnStartup(startCtx) }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-startCtx.Done():
+		if ctx.Err() != nil {
+			// Parent context was cancelled, not a timeout.
+			return ctx.Err()
+		}
+		m.emit(EventTimeout, TimeoutPayload{
+			Name:    e.name,
+			Phase:   "startup",
+			Timeout: timeout.String(),
+		})
+		return errors.New(ErrTimeout,
+			fmt.Sprintf("service %q startup timed out after %s", e.name, timeout), startCtx.Err()).
+			WithField("service", e.name).
+			WithField("timeout", timeout.String())
+	}
+}
+
+// stopService stops a single service, applying a timeout if configured.
+func (m *Manager) stopService(e *entry) error {
+	timeout := m.serviceTimeout(e)
+	if timeout <= 0 {
+		return e.service.OnShutdown()
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- e.service.OnShutdown() }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		m.emit(EventTimeout, TimeoutPayload{
+			Name:    e.name,
+			Phase:   "shutdown",
+			Timeout: timeout.String(),
+		})
+		return errors.New(ErrTimeout,
+			fmt.Sprintf("service %q shutdown timed out after %s", e.name, timeout), nil).
+			WithField("service", e.name).
+			WithField("timeout", timeout.String())
+	}
 }
 
 // rollback shuts down already-started services in reverse order after a

--- a/lifecycle/lifecycle_test.go
+++ b/lifecycle/lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	stderrors "errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jrschumacher/wails-kit/errors"
 	"github.com/jrschumacher/wails-kit/events"
@@ -37,6 +38,36 @@ func (m *mockService) OnShutdown() error {
 	}
 	m.stopped = true
 	return nil
+}
+
+// slowService blocks for a duration on startup and/or shutdown.
+type slowService struct {
+	startDelay time.Duration
+	stopDelay  time.Duration
+}
+
+func (s *slowService) OnStartup(ctx context.Context) error {
+	select {
+	case <-time.After(s.startDelay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *slowService) OnShutdown() error {
+	time.Sleep(s.stopDelay)
+	return nil
+}
+
+// healthyService implements HealthChecker and always returns a fixed status.
+type healthyService struct {
+	mockService
+	status HealthStatus
+}
+
+func (h *healthyService) Health() HealthStatus {
+	return h.status
 }
 
 func TestNewManager_NoDeps(t *testing.T) {
@@ -349,5 +380,234 @@ func TestDiamondDependency(t *testing.T) {
 	}
 	if indexOf("b") >= indexOf("a") || indexOf("c") >= indexOf("a") {
 		t.Fatalf("b and c must come before a, got %v", sorted)
+	}
+}
+
+// --- Timeout tests ---
+
+func TestStartup_GlobalTimeout_Triggers(t *testing.T) {
+	slow := &slowService{startDelay: 500 * time.Millisecond}
+
+	mem := events.NewMemoryEmitter()
+	mgr, err := NewManager(
+		WithService("slow", slow),
+		WithTimeout(50*time.Millisecond),
+		WithEmitter(events.NewEmitter(mem)),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = mgr.Startup(context.Background())
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !errors.IsCode(err, ErrStartup) {
+		t.Fatalf("expected ErrStartup wrapping timeout, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout message, got: %s", err.Error())
+	}
+
+	// Verify timeout event was emitted.
+	var foundTimeout bool
+	for _, evt := range mem.Events() {
+		if evt.Name == EventTimeout {
+			foundTimeout = true
+			payload := evt.Data.(TimeoutPayload)
+			if payload.Name != "slow" || payload.Phase != "startup" {
+				t.Fatalf("unexpected timeout payload: %+v", payload)
+			}
+		}
+	}
+	if !foundTimeout {
+		t.Fatal("expected timeout event")
+	}
+}
+
+func TestStartup_GlobalTimeout_NoTimeoutWhenFast(t *testing.T) {
+	fast := &mockService{name: "fast"}
+
+	mgr, err := NewManager(
+		WithService("fast", fast),
+		WithTimeout(1*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := mgr.Startup(context.Background()); err != nil {
+		t.Fatalf("startup should succeed: %v", err)
+	}
+	if !fast.started {
+		t.Fatal("service should have started")
+	}
+}
+
+func TestStartup_PerServiceTimeout_Overrides(t *testing.T) {
+	// Global timeout is generous, but per-service timeout is short.
+	slow := &slowService{startDelay: 500 * time.Millisecond}
+
+	mgr, err := NewManager(
+		WithService("slow", slow, WithServiceTimeout(50*time.Millisecond)),
+		WithTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = mgr.Startup(context.Background())
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout message, got: %s", err.Error())
+	}
+}
+
+func TestShutdown_Timeout_ContinuesOtherServices(t *testing.T) {
+	fast := &mockService{name: "fast"}
+	slow := &slowService{stopDelay: 500 * time.Millisecond}
+
+	mem := events.NewMemoryEmitter()
+	mgr, err := NewManager(
+		WithService("slow", slow),
+		WithService("fast", fast, DependsOn("slow")),
+		WithTimeout(50*time.Millisecond),
+		WithEmitter(events.NewEmitter(mem)),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := mgr.Startup(context.Background()); err != nil {
+		t.Fatalf("startup failed: %v", err)
+	}
+	mem.Clear()
+
+	err = mgr.Shutdown()
+	if err == nil {
+		t.Fatal("expected shutdown error from timeout")
+	}
+	// The fast service should have stopped successfully despite slow timing out.
+	if !fast.stopped {
+		t.Fatal("fast service should have been stopped")
+	}
+}
+
+func TestStartup_TimeoutTriggersRollback(t *testing.T) {
+	fast := &mockService{name: "fast"}
+	slow := &slowService{startDelay: 500 * time.Millisecond}
+
+	mgr, err := NewManager(
+		WithService("fast", fast),
+		WithService("slow", slow, DependsOn("fast"), WithServiceTimeout(50*time.Millisecond)),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = mgr.Startup(context.Background())
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	// fast should have been rolled back.
+	if !fast.stopped {
+		t.Fatal("fast service should have been rolled back")
+	}
+}
+
+// --- Health check tests ---
+
+func TestHealth_AllHealthy(t *testing.T) {
+	a := &mockService{name: "a"}
+	b := &mockService{name: "b"}
+
+	mgr, err := NewManager(
+		WithService("a", a),
+		WithService("b", b),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mgr.Startup(context.Background()); err != nil {
+		t.Fatalf("startup failed: %v", err)
+	}
+
+	health := mgr.Health()
+	if len(health) != 2 {
+		t.Fatalf("expected 2 health entries, got %d", len(health))
+	}
+	for _, h := range health {
+		if h.Status != StatusHealthy {
+			t.Fatalf("expected healthy, got %s for %s", h.Status, h.Name)
+		}
+	}
+}
+
+func TestHealth_WithHealthChecker(t *testing.T) {
+	a := &mockService{name: "a"}
+	b := &healthyService{
+		mockService: mockService{name: "b"},
+		status:      StatusDegraded,
+	}
+
+	mgr, err := NewManager(
+		WithService("a", a),
+		WithService("b", b),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mgr.Startup(context.Background()); err != nil {
+		t.Fatalf("startup failed: %v", err)
+	}
+
+	health := mgr.Health()
+	statusByName := make(map[string]HealthStatus)
+	for _, h := range health {
+		statusByName[h.Name] = h.Status
+	}
+
+	if statusByName["a"] != StatusHealthy {
+		t.Fatalf("expected a=healthy, got %s", statusByName["a"])
+	}
+	if statusByName["b"] != StatusDegraded {
+		t.Fatalf("expected b=degraded, got %s", statusByName["b"])
+	}
+}
+
+func TestHealth_EmptyBeforeStartup(t *testing.T) {
+	mgr, err := NewManager(
+		WithService("a", &mockService{name: "a"}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	health := mgr.Health()
+	if len(health) != 0 {
+		t.Fatalf("expected 0 health entries before startup, got %d", len(health))
+	}
+}
+
+func TestHealth_Unhealthy(t *testing.T) {
+	svc := &healthyService{
+		mockService: mockService{name: "db"},
+		status:      StatusUnhealthy,
+	}
+
+	mgr, err := NewManager(WithService("db", svc))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mgr.Startup(context.Background()); err != nil {
+		t.Fatalf("startup failed: %v", err)
+	}
+
+	health := mgr.Health()
+	if len(health) != 1 || health[0].Status != StatusUnhealthy {
+		t.Fatalf("expected unhealthy, got %+v", health)
 	}
 }


### PR DESCRIPTION
## Summary
- Add global `WithTimeout` and per-service `WithServiceTimeout` options that wrap startup/shutdown with context deadlines
- Startup timeouts are treated as failures and trigger rollback of already-started services
- Shutdown timeouts are collected as errors but don't prevent other services from shutting down
- Add `HealthChecker` interface for opt-in health reporting; services that implement it report `healthy`/`degraded`/`unhealthy` via `mgr.Health()`
- Add `lifecycle:timeout` event and `lifecycle_timeout` error code

Closes #19, closes #31

## Test plan
- [x] Global startup timeout triggers rollback and emits timeout event
- [x] Fast services complete normally even with timeout configured
- [x] Per-service timeout overrides global timeout
- [x] Shutdown timeout continues shutting down other services
- [x] Startup timeout triggers rollback of previously started services
- [x] Health returns healthy for all services by default
- [x] Health reports status from HealthChecker implementations
- [x] Health returns empty before startup
- [x] All existing tests still pass
- [x] `task check` passes (lint + tests + TS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)