### PR TITLE
fix(llm): log warning on malformed tool input JSON in OpenAI provider

### DIFF
--- a/llm/openai/openai.go
+++ b/llm/openai/openai.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/jrschumacher/wails-kit/llm"
+	"github.com/jrschumacher/wails-kit/logging"
 	openaisdk "github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/option"
 )
@@ -107,7 +108,7 @@ func buildMessages(req llm.ChatRequest) []openaisdk.ChatCompletionMessageParamUn
 					OfFunction: &openaisdk.ChatCompletionMessageFunctionToolCallParam{
 						ID: tu.ID,
 						Function: openaisdk.ChatCompletionMessageFunctionToolCallFunctionParam{
-							Arguments: string(normalizeToolInput(tu.Input)),
+							Arguments: string(normalizeToolInput(tu.Name, tu.Input)),
 							Name:      tu.Name,
 						},
 					},
@@ -162,26 +163,29 @@ func convertToolUses(toolCalls []openaisdk.ChatCompletionMessageToolCallUnion) [
 			result = append(result, llm.ToolUseBlock{
 				ID:    variant.ID,
 				Name:  variant.Function.Name,
-				Input: normalizeToolInput(json.RawMessage(variant.Function.Arguments)),
+				Input: normalizeToolInput(variant.Function.Name, json.RawMessage(variant.Function.Arguments)),
 			})
 		case openaisdk.ChatCompletionMessageCustomToolCall:
 			result = append(result, llm.ToolUseBlock{
 				ID:    variant.ID,
 				Name:  variant.Custom.Name,
-				Input: normalizeToolInput(json.RawMessage(variant.Custom.Input)),
+				Input: normalizeToolInput(variant.Custom.Name, json.RawMessage(variant.Custom.Input)),
 			})
 		}
 	}
 	return result
 }
 
-func normalizeToolInput(input json.RawMessage) json.RawMessage {
+func normalizeToolInput(toolName string, input json.RawMessage) json.RawMessage {
 	if len(input) == 0 {
 		return json.RawMessage(`{}`)
 	}
 	if json.Valid(input) {
 		return input
 	}
+
+	logging.Warn("malformed tool input JSON, wrapping in fallback",
+		"tool", toolName, "raw_input", string(input))
 
 	fallback, err := json.Marshal(map[string]any{"_raw": string(input)})
 	if err != nil {

--- a/llm/openai/openai_test.go
+++ b/llm/openai/openai_test.go
@@ -123,7 +123,7 @@ func TestFinalStreamResult_ReturnsToolUses(t *testing.T) {
 }
 
 func TestNormalizeToolInput_WrapsInvalidJSON(t *testing.T) {
-	got := normalizeToolInput(json.RawMessage(`{"city"`))
+	got := normalizeToolInput("test_tool", json.RawMessage(`{"city"`))
 	if string(got) != `{"_raw":"{\"city\""}` {
 		t.Fatalf("unexpected fallback JSON: %s", got)
 	}


### PR DESCRIPTION
## Summary
Add logging visibility when the OpenAI provider encounters malformed tool input JSON. Previously, invalid JSON was silently wrapped in a fallback object, masking bugs and preventing developers from seeing why tools received unexpected input.

## Changes
- Updated `normalizeToolInput()` to accept tool name parameter and log warnings when fallback is triggered
- Updated all call sites to pass tool name for context
- Updated tests to match new signature

## Why This Matters
Developers now have visibility into when and why the fallback behavior triggers, making it easier to debug tool integration issues.

Closes #35

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>