### PR TITLE
feat(settings): add error code to ValidationError

### DIFF
--- a/settings/validate.go
+++ b/settings/validate.go
@@ -6,9 +6,23 @@ import (
 	"unicode/utf8"
 )
 
+// Validation error codes returned in ValidationError.Code.
+const (
+	CodeRequired      = "required"
+	CodePattern       = "pattern"
+	CodeMinLen        = "min_length"
+	CodeMaxLen        = "max_length"
+	CodeMin           = "min"
+	CodeMax           = "max"
+	CodeInvalidType   = "invalid_type"
+	CodeInvalidOption = "invalid_option"
+)
+
+// ValidationError represents a field-level validation failure.
 type ValidationError struct {
 	Field   string `json:"field"`
 	Message string `json:"message"`
+	Code    string `json:"code"`
 }
 
 func Validate(schema Schema, values map[string]any) []ValidationError {
@@ -57,7 +71,7 @@ func validateField(field Field, val any, values map[string]any) []ValidationErro
 
 	if v != nil && v.Required {
 		if val == nil || (isStr && str == "") {
-			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s is required", field.Label)})
+			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s is required", field.Label), Code: CodeRequired})
 			return errs
 		}
 	}
@@ -65,36 +79,36 @@ func validateField(field Field, val any, values map[string]any) []ValidationErro
 	// Toggle type validation: must be a bool if provided
 	if field.Type == FieldToggle && val != nil {
 		if _, ok := val.(bool); !ok {
-			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be true or false", field.Label)})
+			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be true or false", field.Label), Code: CodeInvalidType})
 		}
 	}
 
 	if isStr && str != "" && v != nil {
 		if v.Pattern != "" {
 			if matched, _ := regexp.MatchString(v.Pattern, str); !matched {
-				errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s has invalid format", field.Label)})
+				errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s has invalid format", field.Label), Code: CodePattern})
 			}
 		}
 		if v.MinLen > 0 && utf8.RuneCountInString(str) < v.MinLen {
-			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be at least %d characters", field.Label, v.MinLen)})
+			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be at least %d characters", field.Label, v.MinLen), Code: CodeMinLen})
 		}
 		if v.MaxLen > 0 && utf8.RuneCountInString(str) > v.MaxLen {
-			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be at most %d characters", field.Label, v.MaxLen)})
+			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be at most %d characters", field.Label, v.MaxLen), Code: CodeMaxLen})
 		}
 	}
 
 	if isNum && v != nil {
 		n := *num
 		if v.Min != nil && n < float64(*v.Min) {
-			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be at least %d", field.Label, *v.Min)})
+			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be at least %d", field.Label, *v.Min), Code: CodeMin})
 		}
 		if v.Max != nil && n > float64(*v.Max) {
-			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be at most %d", field.Label, *v.Max)})
+			errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s must be at most %d", field.Label, *v.Max), Code: CodeMax})
 		}
 	}
 
 	if field.Type == FieldSelect && isStr && str != "" && hasSelectableOptions(field, values) && !selectOptionAllowed(field, str, values) {
-		errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s has an invalid option", field.Label)})
+		errs = append(errs, ValidationError{Field: field.Key, Message: fmt.Sprintf("%s has an invalid option", field.Label), Code: CodeInvalidOption})
 	}
 
 	return errs

--- a/settings/validate_test.go
+++ b/settings/validate_test.go
@@ -33,6 +33,9 @@ func TestValidate_RequiredFieldMissing(t *testing.T) {
 	if errs[0].Message != "Name is required" {
 		t.Errorf("unexpected message: %s", errs[0].Message)
 	}
+	if errs[0].Code != CodeRequired {
+		t.Errorf("expected code=%s, got %s", CodeRequired, errs[0].Code)
+	}
 }
 
 func TestValidate_RequiredFieldEmptyString(t *testing.T) {
@@ -92,6 +95,9 @@ func TestValidate_PatternMismatch(t *testing.T) {
 	if errs[0].Message != "Email has invalid format" {
 		t.Errorf("unexpected message: %s", errs[0].Message)
 	}
+	if errs[0].Code != CodePattern {
+		t.Errorf("expected code=%s, got %s", CodePattern, errs[0].Code)
+	}
 }
 
 func TestValidate_MinLen(t *testing.T) {
@@ -109,6 +115,9 @@ func TestValidate_MinLen(t *testing.T) {
 	if errs[0].Message != "Password must be at least 8 characters" {
 		t.Errorf("unexpected message: %s", errs[0].Message)
 	}
+	if errs[0].Code != CodeMinLen {
+		t.Errorf("expected code=%s, got %s", CodeMinLen, errs[0].Code)
+	}
 }
 
 func TestValidate_MaxLen(t *testing.T) {
@@ -125,6 +134,9 @@ func TestValidate_MaxLen(t *testing.T) {
 	}
 	if errs[0].Message != "Code must be at most 4 characters" {
 		t.Errorf("unexpected message: %s", errs[0].Message)
+	}
+	if errs[0].Code != CodeMaxLen {
+		t.Errorf("expected code=%s, got %s", CodeMaxLen, errs[0].Code)
 	}
 }
 
@@ -193,6 +205,9 @@ func TestValidate_NumberMin(t *testing.T) {
 	if errs[0].Message != "Age must be at least 18" {
 		t.Errorf("unexpected message: %s", errs[0].Message)
 	}
+	if errs[0].Code != CodeMin {
+		t.Errorf("expected code=%s, got %s", CodeMin, errs[0].Code)
+	}
 }
 
 func TestValidate_NumberMax(t *testing.T) {
@@ -209,6 +224,9 @@ func TestValidate_NumberMax(t *testing.T) {
 	}
 	if errs[0].Message != "Count must be at most 100" {
 		t.Errorf("unexpected message: %s", errs[0].Message)
+	}
+	if errs[0].Code != CodeMax {
+		t.Errorf("expected code=%s, got %s", CodeMax, errs[0].Code)
 	}
 }
 
@@ -291,6 +309,9 @@ func TestValidate_ToggleValidation(t *testing.T) {
 	}
 	if errs[0].Message != "Enabled must be true or false" {
 		t.Errorf("unexpected message: %s", errs[0].Message)
+	}
+	if errs[0].Code != CodeInvalidType {
+		t.Errorf("expected code=%s, got %s", CodeInvalidType, errs[0].Code)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a `Code` string field to `ValidationError` with constants: `required`, `pattern`, `min_length`, `max_length`, `min`, `max`, `invalid_type`, `invalid_option`
- Frontends can now programmatically identify which validation rule failed and highlight specific fields with contextual error messages
- Updates existing tests to verify the new `Code` field

Closes #34

## Test plan

- [x] All existing validation tests pass with new `Code` assertions
- [x] `task check` passes (lint + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)