### PR TITLE
fix(ci): add checkout step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: jrschumacher/go-actions/release@v3
         with:
           release-token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow was missing the `actions/checkout@v4` step, which caused `setup-go` to fail with "go.mod does not exist". This matches the pattern used in all CI jobs and follows the `go-actions` ADR about caller-provided checkout.

## Changes

- Added `actions/checkout@v4` before the `jrschumacher/go-actions/release@v3` action

This should fix the failing release run (https://github.com/jrschumacher/wails-kit/actions/runs/22840919363).

🤖 Generated with Claude Code