### PR TITLE
fix(settings): drop stale keys on save

### DIFF
--- a/settings/store.go
+++ b/settings/store.go
@@ -108,13 +108,23 @@ func (s *Store) Save(values map[string]any) error {
 	if err == nil {
 		_ = json.Unmarshal(data, &existing)
 	}
+	mergedValues := make(map[string]any)
+	for k, v := range existing {
+		if len(s.knownKeys) > 0 && !s.knownKeys[k] {
+			continue
+		}
+		mergedValues[k] = v
+	}
 
 	// Merge: new values override existing
 	for k, v := range values {
-		existing[k] = v
+		if len(s.knownKeys) > 0 && !s.knownKeys[k] {
+			continue
+		}
+		mergedValues[k] = v
 	}
 
-	merged, err := json.MarshalIndent(existing, "", "  ")
+	merged, err := json.MarshalIndent(mergedValues, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/settings/store_test.go
+++ b/settings/store_test.go
@@ -178,6 +178,39 @@ func TestLoad_StripsUnknownKeys(t *testing.T) {
 	}
 }
 
+func TestSave_StripsUnknownKeysFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	data, _ := json.Marshal(map[string]any{"known": "yes", "stale": "garbage"})
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+
+	s := NewStore("app", WithPath(path))
+	s.SetKnownKeys(map[string]bool{"known": true})
+
+	if err := s.Save(map[string]any{"known": "updated"}); err != nil {
+		t.Fatalf("save error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+
+	var saved map[string]any
+	if err := json.Unmarshal(raw, &saved); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if saved["known"] != "updated" {
+		t.Fatalf("expected known=updated, got %v", saved["known"])
+	}
+	if _, ok := saved["stale"]; ok {
+		t.Fatal("expected stale key to be removed from disk")
+	}
+}
+
 func TestSave_DirectoryPermissions(t *testing.T) {
 	dir := t.TempDir()
 	subdir := filepath.Join(dir, "newdir")


### PR DESCRIPTION
## Summary
- filter persisted settings through `knownKeys` during save, not just during load
- stop writing removed schema keys back to disk forever
- add a regression test that inspects the raw saved JSON

## Stack
- base PR: #52

## Testing
- go test ./settings
- go test ./llm ./updates ./frontend