### PR TITLE
fix(ci): skip conventional commits check on release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   conventional-commits:
     name: Conventional Commits
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
       "release-type": "go",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": false,
+      "initial-version": "0.1.0"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary
- Skip the "Conventional Commits" CI check on release-please PRs (branch prefix `release-please--`), since the auto-generated PR title uses scope `main` which isn't in the allowed scopes list
- Set `initial-version` to `0.1.0` in release-please config so the first release is v0.1.0 instead of v1.0.0

## Test plan
- [ ] Verify CI passes on this PR (conventional commits check should still run)
- [ ] After merge, verify the release-please PR updates to 0.1.0 and CI passes on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)