### PR TITLE
fix(ci): fix darwin build, entitlements, cask SHA, and local taskfile docs

### DIFF
--- a/.wails-kit.example.yml
+++ b/.wails-kit.example.yml
@@ -27,3 +27,7 @@ signing:
   # Notarytool keychain profile name (created via `xcrun notarytool store-credentials`)
   # Leave empty to skip notarization.
   keychain_profile: ""
+
+  # Path to entitlements plist for hardened runtime (e.g. "build/darwin/entitlements.plist")
+  # Leave empty to sign without entitlements.
+  entitlements: ""

--- a/taskfiles/README.md
+++ b/taskfiles/README.md
@@ -16,7 +16,16 @@ macOS signing also requires Xcode command-line tools (`xcode-select --install`).
 
 1. Copy `.wails-kit.example.yml` to `.wails-kit.yml` in your project root and fill in your values.
 
-2. Include the release Taskfile in your project's root `Taskfile.yml`:
+2. Copy the release Taskfile into your project:
+
+```sh
+mkdir -p taskfiles
+cp "$(go env GOMODCACHE)/github.com/jrschumacher/wails-kit@<version>/taskfiles/release.yml" taskfiles/release.yml
+```
+
+> **Note:** `wails3 task` uses an embedded Task runner that does not support remote taskfiles. You must copy the file locally.
+
+3. Include the release Taskfile in your project's root `Taskfile.yml`:
 
 ```yaml
 version: '3'
@@ -29,7 +38,7 @@ includes:
 
   # wails-kit shared tasks
   release:
-    taskfile: https://raw.githubusercontent.com/jrschumacher/wails-kit/main/taskfiles/release.yml
+    taskfile: ./taskfiles/release.yml
 
 tasks:
   dev:
@@ -52,7 +61,7 @@ task release VERSION=0.3.0
 ```
 
 **Flow on macOS:**
-1. `darwin:build` (Wails-generated)
+1. `darwin:package` (Wails-generated — builds binary and creates .app bundle)
 2. `sign` — codesign with Developer ID (skipped if `signing.developer_id` is empty)
 3. `notarize` — notarytool submit + staple (skipped if `signing.keychain_profile` is empty)
 4. Archive as `.zip`
@@ -80,10 +89,11 @@ release:
 signing:
   developer_id: "Developer ID Application: ..."  # Empty = skip signing
   keychain_profile: AC_PASSWORD                   # Empty = skip notarization
+  entitlements: "build/darwin/entitlements.plist"  # Optional — hardened runtime entitlements
 ```
 
 ## How it works
 
-The shared Taskfile reads `.wails-kit.yml` via `yq` at task invocation time. It calls back into the Wails-generated platform tasks (`:darwin:build`, `:linux:build`) using Taskfile's root-scoped task references.
+The shared Taskfile reads `.wails-kit.yml` via `yq` at task invocation time. It calls back into the Wails-generated platform tasks (`:darwin:package`, `:linux:build`) using Taskfile's root-scoped task references.
 
 Signing and notarization are skipped gracefully when the corresponding config values are empty, so the same Taskfile works in CI (unsigned) and on a developer's machine (signed).

--- a/taskfiles/release.yml
+++ b/taskfiles/release.yml
@@ -4,7 +4,11 @@
 #
 #   includes:
 #     release:
-#       taskfile: https://raw.githubusercontent.com/jrschumacher/wails-kit/main/taskfiles/release.yml
+#       taskfile: ./taskfiles/release.yml
+#
+# To install, copy from the module cache:
+#   mkdir -p taskfiles
+#   cp "$(go env GOMODCACHE)/github.com/jrschumacher/wails-kit@<version>/taskfiles/release.yml" taskfiles/release.yml
 #
 # Requires:
 #   - .wails-kit.yml in the project root (see .wails-kit.example.yml)
@@ -26,6 +30,8 @@ vars:
     sh: yq '.signing.developer_id // ""' .wails-kit.yml
   KIT_KEYCHAIN_PROFILE:
     sh: yq '.signing.keychain_profile // ""' .wails-kit.yml
+  KIT_ENTITLEMENTS:
+    sh: yq '.signing.entitlements // ""' .wails-kit.yml
   BIN_DIR: bin
 
 tasks:
@@ -66,7 +72,7 @@ tasks:
         sh: echo "{{.KIT_APP_NAME}}" | tr '[:upper:]' '[:lower:]'
       ARCHIVE: '{{.APP_LOWER}}-{{.VERSION}}-darwin-{{ARCH}}.zip'
     cmds:
-      - task: ':darwin:build'
+      - task: ':darwin:package'
       - task: sign
       - task: notarize
       - cd "{{.BIN_DIR}}" && zip -r "{{.ARCHIVE}}" "{{.KIT_APP_NAME}}.app"
@@ -103,6 +109,7 @@ tasks:
       - |
         codesign --force --deep --options runtime \
           --sign "{{.KIT_DEVELOPER_ID}}" \
+          {{if .KIT_ENTITLEMENTS}}--entitlements "{{.KIT_ENTITLEMENTS}}" {{end}}\
           "{{.BIN_DIR}}/{{.KIT_APP_NAME}}.app"
       - echo "Signed {{.KIT_APP_NAME}}.app with {{.KIT_DEVELOPER_ID}}"
 
@@ -166,11 +173,17 @@ tasks:
         # Update version
         sed -i'' -e 's/version "[^"]*"/version "{{.VERSION}}"/' "$CASK_FILE"
 
-        # Update SHA for the current architecture
-        if [ "{{ARCH}}" = "arm64" ]; then
-          sed -i'' -e '/arm64/,/sha256/{s/sha256 "[^"]*"/sha256 "{{.SHA}}"/;}' "$CASK_FILE"
+        # Update SHA — detect multi-arch vs single-arch cask
+        if grep -q 'arch arm64\|on_arm\|hardware.arch' "$CASK_FILE" 2>/dev/null; then
+          # Multi-arch cask: update SHA within the architecture-specific block
+          if [ "{{ARCH}}" = "arm64" ]; then
+            sed -i'' -e '/arm64/,/sha256/{s/sha256 "[^"]*"/sha256 "{{.SHA}}"/;}' "$CASK_FILE"
+          else
+            sed -i'' -e '/intel/,/sha256/{s/sha256 "[^"]*"/sha256 "{{.SHA}}"/;}' "$CASK_FILE"
+          fi
         else
-          sed -i'' -e '/intel/,/sha256/{s/sha256 "[^"]*"/sha256 "{{.SHA}}"/;}' "$CASK_FILE"
+          # Single-arch cask: replace the only sha256 line
+          sed -i'' -e 's/sha256 "[^"]*"/sha256 "{{.SHA}}"/' "$CASK_FILE"
         fi
 
         cd "$TMPDIR/tap"


### PR DESCRIPTION
## Summary

- **#60**: Use `darwin:package` instead of `darwin:build` so the release produces a `.app` bundle (not a raw binary)
- **#63**: Add optional `signing.entitlements` field to `.wails-kit.yml` and pass `--entitlements` to `codesign` when set
- **#62**: Detect single-arch vs multi-arch cask formulas — single-arch casks now get a simple `sha256` replacement instead of the range-based sed that requires architecture markers
- **#61**: Document local taskfile copy as the primary setup method since `wails3 task` doesn't support remote taskfiles

Closes #60, closes #61, closes #62, closes #63

## Test plan

- [ ] Run `task release` on macOS and verify `.app` bundle is produced and signed
- [ ] Test with `signing.entitlements` set to a plist path — verify `--entitlements` flag is passed to codesign
- [ ] Test with `signing.entitlements` empty — verify codesign runs without `--entitlements`
- [ ] Test `update-cask` against a single-arch cask formula — verify SHA is updated
- [ ] Test `update-cask` against a multi-arch cask formula — verify correct arch SHA is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)