### PR TITLE
feat(database): add WithBaselineVersion for pre-existing schemas

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -69,6 +69,23 @@ Migrations run automatically on `New()`. Use `Version()` to check the current sc
 version, err := db.Version()
 ```
 
+### Baseline version (adopting wails-kit with existing tables)
+
+When integrating wails-kit into an app that already has SQLite tables, migrations will fail because goose tries to run all migrations from scratch. Use `WithBaselineVersion` to stamp existing migrations as applied:
+
+```go
+db, err := database.New(
+    database.WithPath(path),
+    database.WithMigrations(migrations),
+    database.WithBaselineVersion(2), // stamp versions 0-2 if no goose table exists
+)
+```
+
+**Behavior:**
+- If `goose_db_version` table already exists → no-op (goose is already tracking)
+- If the database has no user tables (fresh) → no-op (let goose run from scratch)
+- If the database has tables but no goose tracking → creates `goose_db_version` and stamps versions 0 through n, then runs any remaining migrations
+
 ### External database connection
 
 If you manage the `*sql.DB` yourself:
@@ -90,6 +107,7 @@ db, err := database.New(
 | `WithMigrations(fs)` | `fs.FS` containing goose SQL migration files |
 | `WithEmitter(e)` | Event emitter for lifecycle events |
 | `WithPragmas(map)` | Override or extend default SQLite pragmas |
+| `WithBaselineVersion(n)` | Stamp versions 0–n as applied for pre-existing databases |
 | `WithDB(db)` | Use an existing `*sql.DB` (caller retains ownership) |
 
 ## Default pragmas
@@ -126,3 +144,4 @@ database.WithPragmas(map[string]string{
 |------|-------------|
 | `database_open` | Unable to open the database. Please check file permissions and try again. |
 | `database_migrate` | Database migration failed. Please contact support. |
+| `database_baseline` | Database baseline failed. Please contact support. |

--- a/database/database.go
+++ b/database/database.go
@@ -20,14 +20,16 @@ import (
 
 // Error codes for the database package.
 const (
-	ErrDatabaseOpen    errors.Code = "database_open"
-	ErrDatabaseMigrate errors.Code = "database_migrate"
+	ErrDatabaseOpen     errors.Code = "database_open"
+	ErrDatabaseMigrate  errors.Code = "database_migrate"
+	ErrDatabaseBaseline errors.Code = "database_baseline"
 )
 
 func init() {
 	errors.RegisterMessages(map[errors.Code]string{
-		ErrDatabaseOpen:    "Unable to open the database. Please check file permissions and try again.",
-		ErrDatabaseMigrate: "Database migration failed. Please contact support.",
+		ErrDatabaseOpen:     "Unable to open the database. Please check file permissions and try again.",
+		ErrDatabaseMigrate:  "Database migration failed. Please contact support.",
+		ErrDatabaseBaseline: "Database baseline failed. Please contact support.",
 	})
 }
 
@@ -53,13 +55,14 @@ var defaultPragmas = map[string]string{
 
 // DB manages a SQLite database with schema migrations.
 type DB struct {
-	db         *sql.DB
-	emitter    *events.Emitter
-	path       string
-	owned      bool // true if we opened the *sql.DB and should close it
-	appName    string
-	migrations fs.FS
-	pragmas    map[string]string
+	db              *sql.DB
+	emitter         *events.Emitter
+	path            string
+	owned           bool // true if we opened the *sql.DB and should close it
+	appName         string
+	migrations      fs.FS
+	pragmas         map[string]string
+	baselineVersion int64
 }
 
 // Option configures a DB instance.
@@ -104,6 +107,19 @@ func WithPragmas(pragmas map[string]string) Option {
 		for k, v := range pragmas {
 			d.pragmas[k] = v
 		}
+	}
+}
+
+// WithBaselineVersion stamps migration versions 0 through n as applied when
+// the database has existing tables but no goose version tracking. This handles
+// the "baseline migration" problem when adopting wails-kit in an app that
+// already has a schema matching migration n.
+//
+// If the goose_db_version table already exists, this is a no-op.
+// If the database has no user tables (fresh database), this is a no-op.
+func WithBaselineVersion(n int64) Option {
+	return func(d *DB) {
+		d.baselineVersion = n
 	}
 }
 
@@ -160,6 +176,16 @@ func New(opts ...Option) (*DB, error) {
 			_ = d.db.Close()
 		}
 		return nil, err
+	}
+
+	// Apply baseline version if configured.
+	if d.baselineVersion > 0 {
+		if err := d.baseline(); err != nil {
+			if d.owned {
+				_ = d.db.Close()
+			}
+			return nil, err
+		}
 	}
 
 	// Run migrations if provided.
@@ -249,6 +275,54 @@ func (d *DB) migrate() error {
 			Version: version,
 			Applied: len(results),
 		})
+	}
+
+	return nil
+}
+
+func (d *DB) baseline() error {
+	// Check if goose_db_version table already exists.
+	var gooseTableExists bool
+	err := d.db.QueryRow(
+		"SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='goose_db_version'",
+	).Scan(&gooseTableExists)
+	if err != nil {
+		return errors.Wrap(ErrDatabaseBaseline, "check goose table", err)
+	}
+	if gooseTableExists {
+		return nil
+	}
+
+	// Check if the database has any user tables.
+	var hasUserTables bool
+	err = d.db.QueryRow(
+		"SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+	).Scan(&hasUserTables)
+	if err != nil {
+		return errors.Wrap(ErrDatabaseBaseline, "check user tables", err)
+	}
+	if !hasUserTables {
+		return nil
+	}
+
+	// Database has existing tables but no goose tracking — stamp baseline.
+	_, err = d.db.Exec(`CREATE TABLE goose_db_version (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		version_id INTEGER NOT NULL,
+		is_applied INTEGER NOT NULL,
+		tstamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	)`)
+	if err != nil {
+		return errors.Wrap(ErrDatabaseBaseline, "create goose table", err)
+	}
+
+	for v := int64(0); v <= d.baselineVersion; v++ {
+		_, err = d.db.Exec(
+			"INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?)", v, 1,
+		)
+		if err != nil {
+			return errors.Wrap(ErrDatabaseBaseline, fmt.Sprintf("stamp version %d", v), err)
+		}
 	}
 
 	return nil

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -321,3 +321,161 @@ func TestNew_CreatesParentDirectories(t *testing.T) {
 		t.Error("parent directories were not created")
 	}
 }
+
+func TestNew_WithBaselineVersion_ExistingDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Simulate a pre-existing database with tables matching migrations 1-2.
+	preDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open error: %v", err)
+	}
+	_, err = preDB.Exec(`
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			email TEXT NOT NULL UNIQUE,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		t.Fatalf("CREATE TABLE error: %v", err)
+	}
+	_ = preDB.Close()
+
+	// Open with baseline version 2 — should stamp and not re-run migrations.
+	db, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+		WithBaselineVersion(2),
+	)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	version, err := db.Version()
+	if err != nil {
+		t.Fatalf("Version() error: %v", err)
+	}
+	if version != 2 {
+		t.Errorf("Version() = %d, want 2", version)
+	}
+}
+
+func TestNew_WithBaselineVersion_FreshDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Fresh database — baseline should be a no-op, migrations run normally.
+	db, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+		WithBaselineVersion(2),
+	)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	version, err := db.Version()
+	if err != nil {
+		t.Fatalf("Version() error: %v", err)
+	}
+	if version != 2 {
+		t.Errorf("Version() = %d, want 2", version)
+	}
+
+	// Verify migrations actually ran (table exists with correct schema).
+	_, err = db.DB().Exec("INSERT INTO users (name, email) VALUES (?, ?)", "Bob", "bob@example.com")
+	if err != nil {
+		t.Fatalf("INSERT error: %v", err)
+	}
+}
+
+func TestNew_WithBaselineVersion_GooseTableExists(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Run migrations first to create goose_db_version table.
+	db1, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+	)
+	if err != nil {
+		t.Fatalf("first New() error: %v", err)
+	}
+	_ = db1.Close()
+
+	// Re-open with baseline — should be a no-op since goose table exists.
+	db2, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+		WithBaselineVersion(2),
+	)
+	if err != nil {
+		t.Fatalf("second New() error: %v", err)
+	}
+	defer func() { _ = db2.Close() }()
+
+	version, err := db2.Version()
+	if err != nil {
+		t.Fatalf("Version() error: %v", err)
+	}
+	if version != 2 {
+		t.Errorf("Version() = %d, want 2", version)
+	}
+}
+
+func TestNew_WithBaselineVersion_PartialMigrations(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Simulate a pre-existing database with only migration 1 applied.
+	preDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open error: %v", err)
+	}
+	_, err = preDB.Exec(`
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			email TEXT NOT NULL UNIQUE
+		)
+	`)
+	if err != nil {
+		t.Fatalf("CREATE TABLE error: %v", err)
+	}
+	_ = preDB.Close()
+
+	// Baseline at version 1 — migration 2 should still run.
+	db, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+		WithBaselineVersion(1),
+	)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	version, err := db.Version()
+	if err != nil {
+		t.Fatalf("Version() error: %v", err)
+	}
+	if version != 2 {
+		t.Errorf("Version() = %d, want 2", version)
+	}
+
+	// Verify migration 2 ran (created_at column exists).
+	var createdAt sql.NullString
+	_, err = db.DB().Exec("INSERT INTO users (name, email) VALUES (?, ?)", "Alice", "alice@example.com")
+	if err != nil {
+		t.Fatalf("INSERT error: %v", err)
+	}
+	err = db.DB().QueryRow("SELECT created_at FROM users WHERE id = 1").Scan(&createdAt)
+	if err != nil {
+		t.Fatalf("SELECT created_at error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `WithBaselineVersion(n int64)` option to `database.New()` that stamps migration versions 0–n as applied when adopting wails-kit in an app with pre-existing SQLite tables
- No-op when `goose_db_version` table already exists (already tracking) or when the database is fresh (no user tables)
- Adds `ErrDatabaseBaseline` error code for baseline failures

## Test plan

- [x] Existing DB with tables matching baseline version → stamps and skips those migrations
- [x] Fresh DB → baseline is no-op, all migrations run normally
- [x] DB with goose table already present → baseline is no-op
- [x] Partial baseline (baseline < max migration) → stamps baseline, runs remaining migrations
- [x] All existing tests still pass
- [x] `task check` passes (lint + tests)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)