### PR TITLE
feat(database): add schema version guard and pre-migration backup

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -86,6 +86,40 @@ db, err := database.New(
 - If the database has no user tables (fresh) → no-op (let goose run from scratch)
 - If the database has tables but no goose tracking → creates `goose_db_version` and stamps versions 0 through n, then runs any remaining migrations
 
+### Schema version guard
+
+The database package automatically protects against schema version mismatches caused by app downgrades. After running migrations, `PRAGMA user_version` is set to the highest migration version. On subsequent opens, if the database's version is higher than the app's max migration, a clear error is returned instead of silently proceeding:
+
+```
+database schema version 5 is newer than this app supports (max 3); please update the app
+```
+
+This is automatic — no configuration needed.
+
+### Pre-migration backup
+
+Enable automatic backups before migrations run. If any migrations are pending, the database is copied before they are applied:
+
+```go
+db, err := database.New(
+    database.WithPath(path),
+    database.WithMigrations(migrations),
+    database.WithBackupBeforeMigration(true),
+)
+```
+
+**Behavior:**
+- Only creates a backup when there are pending migrations (not on every startup)
+- Names the backup with the current version: `data.db.backup-v2`
+- Keeps at most 3 backups by default, deleting oldest (configurable via `WithMaxBackups`)
+- Skips backup for fresh installs (no prior version stamp)
+- Uses `VACUUM INTO` for a consistent copy that handles WAL mode correctly
+
+```go
+database.WithBackupBeforeMigration(true),
+database.WithMaxBackups(5), // keep 5 backups instead of default 3
+```
+
 ### External database connection
 
 If you manage the `*sql.DB` yourself:
@@ -108,6 +142,8 @@ db, err := database.New(
 | `WithEmitter(e)` | Event emitter for lifecycle events |
 | `WithPragmas(map)` | Override or extend default SQLite pragmas |
 | `WithBaselineVersion(n)` | Stamp versions 0–n as applied for pre-existing databases |
+| `WithBackupBeforeMigration(bool)` | Create a backup before running pending migrations |
+| `WithMaxBackups(n)` | Maximum number of pre-migration backups to retain (default 3) |
 | `WithDB(db)` | Use an existing `*sql.DB` (caller retains ownership) |
 
 ## Default pragmas
@@ -145,3 +181,5 @@ database.WithPragmas(map[string]string{
 | `database_open` | Unable to open the database. Please check file permissions and try again. |
 | `database_migrate` | Database migration failed. Please contact support. |
 | `database_baseline` | Database baseline failed. Please contact support. |
+| `database_version_mismatch` | The database was created by a newer version of this app. Please update the app. |
+| `database_backup` | Failed to create a database backup before migration. Please check disk space and try again. |

--- a/database/database.go
+++ b/database/database.go
@@ -10,6 +10,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/jrschumacher/wails-kit/appdirs"
 	"github.com/jrschumacher/wails-kit/errors"
@@ -20,16 +22,20 @@ import (
 
 // Error codes for the database package.
 const (
-	ErrDatabaseOpen     errors.Code = "database_open"
-	ErrDatabaseMigrate  errors.Code = "database_migrate"
-	ErrDatabaseBaseline errors.Code = "database_baseline"
+	ErrDatabaseOpen            errors.Code = "database_open"
+	ErrDatabaseMigrate         errors.Code = "database_migrate"
+	ErrDatabaseBaseline        errors.Code = "database_baseline"
+	ErrDatabaseVersionMismatch errors.Code = "database_version_mismatch"
+	ErrDatabaseBackup          errors.Code = "database_backup"
 )
 
 func init() {
 	errors.RegisterMessages(map[errors.Code]string{
-		ErrDatabaseOpen:     "Unable to open the database. Please check file permissions and try again.",
-		ErrDatabaseMigrate:  "Database migration failed. Please contact support.",
-		ErrDatabaseBaseline: "Database baseline failed. Please contact support.",
+		ErrDatabaseOpen:            "Unable to open the database. Please check file permissions and try again.",
+		ErrDatabaseMigrate:         "Database migration failed. Please contact support.",
+		ErrDatabaseBaseline:        "Database baseline failed. Please contact support.",
+		ErrDatabaseVersionMismatch: "The database was created by a newer version of this app. Please update the app.",
+		ErrDatabaseBackup:          "Failed to create a database backup before migration. Please check disk space and try again.",
 	})
 }
 
@@ -55,14 +61,16 @@ var defaultPragmas = map[string]string{
 
 // DB manages a SQLite database with schema migrations.
 type DB struct {
-	db              *sql.DB
-	emitter         *events.Emitter
-	path            string
-	owned           bool // true if we opened the *sql.DB and should close it
-	appName         string
-	migrations      fs.FS
-	pragmas         map[string]string
-	baselineVersion int64
+	db                    *sql.DB
+	emitter               *events.Emitter
+	path                  string
+	owned                 bool // true if we opened the *sql.DB and should close it
+	appName               string
+	migrations            fs.FS
+	pragmas               map[string]string
+	baselineVersion       int64
+	backupBeforeMigration bool
+	maxBackups            int
 }
 
 // Option configures a DB instance.
@@ -120,6 +128,27 @@ func WithPragmas(pragmas map[string]string) Option {
 func WithBaselineVersion(n int64) Option {
 	return func(d *DB) {
 		d.baselineVersion = n
+	}
+}
+
+// WithBackupBeforeMigration enables automatic database backup before running
+// pending migrations. When enabled, a copy of the database file is created
+// (e.g., data.db.backup-v2) before any new migrations are applied. Backups
+// are only created when there are pending migrations and the database file
+// exists (not on fresh installs). Old backups beyond the retention limit are
+// automatically cleaned up (default 3, configurable via WithMaxBackups).
+func WithBackupBeforeMigration(enabled bool) Option {
+	return func(d *DB) {
+		d.backupBeforeMigration = enabled
+	}
+}
+
+// WithMaxBackups sets the maximum number of pre-migration backups to retain.
+// Oldest backups are deleted when the limit is exceeded. Defaults to 3.
+// Only effective when WithBackupBeforeMigration is enabled.
+func WithMaxBackups(n int) Option {
+	return func(d *DB) {
+		d.maxBackups = n
 	}
 }
 
@@ -264,9 +293,50 @@ func (d *DB) migrate() error {
 		return errors.Wrap(ErrDatabaseMigrate, "create goose provider", err)
 	}
 
+	// Determine the max migration version from the migration sources.
+	sources := provider.ListSources()
+	var maxVersion int64
+	if len(sources) > 0 {
+		maxVersion = sources[len(sources)-1].Version
+	}
+
+	// Read current user_version for version guard and backup decisions.
+	var userVersion int64
+	if maxVersion > 0 {
+		if err := d.db.QueryRow("PRAGMA user_version").Scan(&userVersion); err != nil {
+			return errors.Wrap(ErrDatabaseMigrate, "read user_version", err)
+		}
+		// Schema version guard: reject if the DB was migrated by a newer app.
+		if userVersion > maxVersion {
+			return errors.New(ErrDatabaseVersionMismatch,
+				fmt.Sprintf("database schema version %d is newer than this app supports (max %d); please update the app", userVersion, maxVersion), nil)
+		}
+	}
+
+	// Pre-migration backup if enabled.
+	// Skip for fresh databases (user_version == 0 means no prior version stamp).
+	if d.backupBeforeMigration && d.path != "" && userVersion > 0 {
+		pending, err := provider.HasPending(context.Background())
+		if err != nil {
+			return errors.Wrap(ErrDatabaseMigrate, "check pending migrations", err)
+		}
+		if pending {
+			if err := d.createBackup(); err != nil {
+				return err
+			}
+		}
+	}
+
 	results, err := provider.Up(context.Background())
 	if err != nil {
 		return errors.Wrap(ErrDatabaseMigrate, "run migrations", err)
+	}
+
+	// Stamp PRAGMA user_version so future downgrades are detected.
+	if maxVersion > 0 {
+		if _, err := d.db.Exec(fmt.Sprintf("PRAGMA user_version = %d", maxVersion)); err != nil {
+			return errors.Wrap(ErrDatabaseMigrate, "set user_version", err)
+		}
 	}
 
 	if len(results) > 0 {
@@ -326,6 +396,53 @@ func (d *DB) baseline() error {
 	}
 
 	return nil
+}
+
+func (d *DB) createBackup() error {
+	// Read current version for the backup filename.
+	var currentVersion int64
+	_ = d.db.QueryRow("PRAGMA user_version").Scan(&currentVersion)
+
+	backupPath := fmt.Sprintf("%s.backup-v%d", d.path, currentVersion)
+
+	// Remove existing backup at this path (e.g., from a previous failed attempt).
+	_ = os.Remove(backupPath)
+
+	// Use VACUUM INTO for a consistent copy that handles WAL mode correctly.
+	escapedPath := strings.ReplaceAll(backupPath, "'", "''")
+	if _, err := d.db.Exec(fmt.Sprintf("VACUUM INTO '%s'", escapedPath)); err != nil {
+		return errors.Wrap(ErrDatabaseBackup, "create backup", err)
+	}
+
+	d.cleanOldBackups()
+	return nil
+}
+
+func (d *DB) cleanOldBackups() {
+	maxBackups := d.maxBackups
+	if maxBackups <= 0 {
+		maxBackups = 3
+	}
+
+	pattern := d.path + ".backup-v*"
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) <= maxBackups {
+		return
+	}
+
+	// Sort by modification time (oldest first).
+	sort.Slice(matches, func(i, j int) bool {
+		fi, errI := os.Stat(matches[i])
+		fj, errJ := os.Stat(matches[j])
+		if errI != nil || errJ != nil {
+			return false
+		}
+		return fi.ModTime().Before(fj.ModTime())
+	})
+
+	for _, m := range matches[:len(matches)-maxBackups] {
+		_ = os.Remove(m)
+	}
 }
 
 func (d *DB) emit(name string, data any) {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -2,8 +2,10 @@ package database
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -477,5 +479,256 @@ func TestNew_WithBaselineVersion_PartialMigrations(t *testing.T) {
 	err = db.DB().QueryRow("SELECT created_at FROM users WHERE id = 1").Scan(&createdAt)
 	if err != nil {
 		t.Fatalf("SELECT created_at error: %v", err)
+	}
+}
+
+func TestNew_VersionGuard_SetsUserVersion(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+	)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// After migrations, PRAGMA user_version should be set to max migration version.
+	var userVersion int64
+	if err := db.DB().QueryRow("PRAGMA user_version").Scan(&userVersion); err != nil {
+		t.Fatalf("PRAGMA user_version error: %v", err)
+	}
+	if userVersion != 2 {
+		t.Errorf("user_version = %d, want 2", userVersion)
+	}
+}
+
+func TestNew_VersionGuard_RejectsNewerDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// First: create DB with migrations and a high user_version (simulating a newer app).
+	db1, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+	)
+	if err != nil {
+		t.Fatalf("first New() error: %v", err)
+	}
+	// Simulate a newer app having set user_version to 5.
+	_, err = db1.DB().Exec("PRAGMA user_version = 5")
+	if err != nil {
+		t.Fatalf("set user_version error: %v", err)
+	}
+	_ = db1.Close()
+
+	// Second: open with same migrations (max version 2) — should fail.
+	_, err = New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+	)
+	if err == nil {
+		t.Fatal("expected error when DB version is newer than app supports")
+	}
+
+	// Verify it's the right error code.
+	if !strings.Contains(err.Error(), "database schema version 5 is newer than this app supports (max 2)") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestNew_VersionGuard_AllowsSameVersion(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// First run: creates and migrates.
+	db1, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+	)
+	if err != nil {
+		t.Fatalf("first New() error: %v", err)
+	}
+	_ = db1.Close()
+
+	// Second run with same migrations — should succeed.
+	db2, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+	)
+	if err != nil {
+		t.Fatalf("second New() error: %v", err)
+	}
+	defer func() { _ = db2.Close() }()
+}
+
+func TestNew_BackupBeforeMigration_CreatesBackup(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create initial DB with first migration only.
+	migrations1 := &fstest.MapFS{
+		"001_create_users.sql": &fstest.MapFile{
+			Data: []byte(`-- +goose Up
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE
+);
+
+-- +goose Down
+DROP TABLE users;
+`),
+		},
+	}
+
+	db1, err := New(
+		WithPath(dbPath),
+		WithMigrations(migrations1),
+	)
+	if err != nil {
+		t.Fatalf("first New() error: %v", err)
+	}
+	_ = db1.Close()
+
+	// Re-open with both migrations and backup enabled.
+	db2, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+		WithBackupBeforeMigration(true),
+	)
+	if err != nil {
+		t.Fatalf("second New() error: %v", err)
+	}
+	defer func() { _ = db2.Close() }()
+
+	// Backup should exist with the pre-migration version (1).
+	backupPath := dbPath + ".backup-v1"
+	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+		t.Error("backup file was not created")
+	}
+
+	// Verify backup is a valid SQLite database with the old schema.
+	backupDB, err := sql.Open("sqlite", backupPath)
+	if err != nil {
+		t.Fatalf("open backup error: %v", err)
+	}
+	defer func() { _ = backupDB.Close() }()
+
+	// The backup should have the users table but no created_at column (pre-migration 2).
+	_, err = backupDB.Exec("INSERT INTO users (name, email) VALUES (?, ?)", "Test", "test@example.com")
+	if err != nil {
+		t.Fatalf("backup INSERT error: %v", err)
+	}
+}
+
+func TestNew_BackupBeforeMigration_SkipsWhenNoMigrations(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create DB with all migrations applied.
+	db1, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+	)
+	if err != nil {
+		t.Fatalf("first New() error: %v", err)
+	}
+	_ = db1.Close()
+
+	// Re-open with backup enabled — no pending migrations, so no backup.
+	db2, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+		WithBackupBeforeMigration(true),
+	)
+	if err != nil {
+		t.Fatalf("second New() error: %v", err)
+	}
+	defer func() { _ = db2.Close() }()
+
+	// No backup should exist.
+	matches, _ := filepath.Glob(dbPath + ".backup-v*")
+	if len(matches) > 0 {
+		t.Errorf("expected no backup files, found %v", matches)
+	}
+}
+
+func TestNew_BackupBeforeMigration_SkipsFreshDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Fresh DB with backup enabled — file doesn't exist yet, so no backup.
+	db, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+		WithBackupBeforeMigration(true),
+	)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	matches, _ := filepath.Glob(dbPath + ".backup-v*")
+	if len(matches) > 0 {
+		t.Errorf("expected no backup files for fresh DB, found %v", matches)
+	}
+}
+
+func TestNew_BackupBeforeMigration_CleansOldBackups(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create fake old backup files.
+	for i := 0; i < 5; i++ {
+		backupPath := fmt.Sprintf("%s.backup-v%d", dbPath, i)
+		if err := os.WriteFile(backupPath, []byte("fake"), 0600); err != nil {
+			t.Fatalf("create fake backup error: %v", err)
+		}
+	}
+
+	// Create initial DB with first migration.
+	migrations1 := &fstest.MapFS{
+		"001_create_users.sql": &fstest.MapFile{
+			Data: []byte(`-- +goose Up
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE
+);
+
+-- +goose Down
+DROP TABLE users;
+`),
+		},
+	}
+
+	db1, err := New(
+		WithPath(dbPath),
+		WithMigrations(migrations1),
+	)
+	if err != nil {
+		t.Fatalf("first New() error: %v", err)
+	}
+	_ = db1.Close()
+
+	// Re-open with all migrations, backup enabled, maxBackups = 2.
+	db2, err := New(
+		WithPath(dbPath),
+		WithMigrations(testMigrations()),
+		WithBackupBeforeMigration(true),
+		WithMaxBackups(2),
+	)
+	if err != nil {
+		t.Fatalf("second New() error: %v", err)
+	}
+	defer func() { _ = db2.Close() }()
+
+	// Should have at most 2 backup files.
+	matches, _ := filepath.Glob(dbPath + ".backup-v*")
+	if len(matches) > 2 {
+		t.Errorf("expected at most 2 backup files, found %d: %v", len(matches), matches)
 	}
 }


### PR DESCRIPTION
## Summary
- **Schema version guard** (automatic): After migrations, stamps `PRAGMA user_version` with the max migration version. On subsequent opens, rejects databases migrated by a newer app with a clear error message, preventing silent data corruption from downgrades.
- **Pre-migration backup** (`WithBackupBeforeMigration`): Creates a consistent database copy via `VACUUM INTO` before running pending migrations. Automatically cleans up old backups beyond a configurable retention limit (default 3, via `WithMaxBackups`). Skips backup for fresh installs and when no migrations are pending.

Closes #68

## Test plan
- [x] `TestNew_VersionGuard_SetsUserVersion` — verifies `PRAGMA user_version` is set after migrations
- [x] `TestNew_VersionGuard_RejectsNewerDB` — verifies error when DB version exceeds app's max migration
- [x] `TestNew_VersionGuard_AllowsSameVersion` — verifies re-open with same migrations succeeds
- [x] `TestNew_BackupBeforeMigration_CreatesBackup` — verifies backup file created with correct content
- [x] `TestNew_BackupBeforeMigration_SkipsWhenNoMigrations` — no backup when all migrations applied
- [x] `TestNew_BackupBeforeMigration_SkipsFreshDB` — no backup on first run
- [x] `TestNew_BackupBeforeMigration_CleansOldBackups` — old backups cleaned beyond max
- [x] All 23 tests pass, lint clean via `task check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)