### PR TITLE
feat: cross-platform builds and managed install detection

### DIFF
--- a/taskfiles/README.md
+++ b/taskfiles/README.md
@@ -35,6 +35,7 @@ includes:
   common: ./build/Taskfile.yml
   darwin: ./build/darwin/Taskfile.yml
   linux: ./build/linux/Taskfile.yml
+  windows: ./build/windows/Taskfile.yml
 
   # wails-kit shared tasks
   release:
@@ -46,6 +47,28 @@ tasks:
       - wails3 dev -config ./build/config.yml
 ```
 
+## Supported platforms
+
+| OS | Architecture | Archive | Upload | Codesign | Notarize | Homebrew Cask |
+|----|-------------|---------|--------|----------|----------|---------------|
+| macOS | arm64 | `.zip` | Yes | Yes | Yes | Yes |
+| macOS | amd64 | `.zip` | Yes | Yes | Yes | Yes |
+| macOS | universal | `.zip` | Yes | Yes | Yes | Yes |
+| Linux | amd64 | `.tar.gz` | Yes | — | — | — |
+| Linux | arm64 | `.tar.gz` | Yes | — | — | — |
+| Windows | amd64 | `.zip` | Yes | — | — | — |
+| Windows | arm64 | `.zip` | Yes | — | — | — |
+
+All archives are uploaded to the tap repo's GitHub Releases, which serves as the central artifact store.
+
+### Distribution
+
+The release taskfile handles building, signing, and uploading. How users install the app depends on the platform:
+
+- **macOS** — Homebrew Cask (`brew install --cask app`). The taskfile auto-updates the cask formula after upload.
+- **Linux** — Direct download from the GitHub release, or packaged for distro-specific formats (`.deb`, `.rpm`, Flatpak) outside this taskfile.
+- **Windows** — Direct download from the GitHub release. Can also be published to [Scoop](https://scoop.sh/) or [winget](https://github.com/microsoft/winget-pkgs) separately.
+
 ## Available tasks
 
 ### `release` (default)
@@ -53,14 +76,34 @@ tasks:
 Builds, signs (macOS), archives, uploads to your Homebrew tap, and updates the cask.
 
 ```sh
-# Uses latest GitHub release tag
+# Uses latest GitHub release tag, host OS and architecture
 task release
 
 # Explicit version
 task release VERSION=0.3.0
+
+# Build for a specific architecture
+task release TARGET_ARCH=amd64
+
+# Build a macOS universal binary (arm64 + amd64 via lipo)
+task release TARGET_ARCH=universal
 ```
 
-**Flow on macOS:**
+### `release:all`
+
+Builds releases for multiple OS/architecture combinations in sequence.
+
+```sh
+# Default targets: darwin/universal, linux/amd64, linux/arm64, windows/amd64
+task release:all VERSION=0.3.0
+
+# Custom target list
+task release:all VERSION=0.3.0 TARGETS=darwin/arm64,linux/amd64,windows/amd64
+```
+
+## Platform details
+
+**macOS (`release-darwin`):**
 1. `darwin:package` (Wails-generated — builds binary and creates .app bundle)
 2. `sign` — codesign with Developer ID (skipped if `signing.developer_id` is empty)
 3. `notarize` — notarytool submit + staple (skipped if `signing.keychain_profile` is empty)
@@ -68,10 +111,17 @@ task release VERSION=0.3.0
 5. Upload to Homebrew tap release
 6. Update Homebrew cask formula
 
-**Flow on Linux:**
+When `TARGET_ARCH=universal`, builds both arm64 and amd64, merges with `lipo`, then signs and archives.
+
+**Linux (`release-linux`):**
 1. `linux:build` (Wails-generated)
 2. Archive as `.tar.gz`
-3. Upload to Homebrew tap release
+3. Upload to GitHub release
+
+**Windows (`release-windows`):**
+1. `windows:build` (Wails-generated)
+2. Archive as `.zip`
+3. Upload to GitHub release
 
 ## Configuration
 
@@ -94,6 +144,6 @@ signing:
 
 ## How it works
 
-The shared Taskfile reads `.wails-kit.yml` via `yq` at task invocation time. It calls back into the Wails-generated platform tasks (`:darwin:package`, `:linux:build`) using Taskfile's root-scoped task references.
+The shared Taskfile reads `.wails-kit.yml` via `yq` at task invocation time. It calls back into the Wails-generated platform tasks (`:darwin:package`, `:linux:build`, `:windows:build`) using Taskfile's root-scoped task references.
 
 Signing and notarization are skipped gracefully when the corresponding config values are empty, so the same Taskfile works in CI (unsigned) and on a developer's machine (signed).

--- a/taskfiles/release.yml
+++ b/taskfiles/release.yml
@@ -14,7 +14,7 @@
 #   - .wails-kit.yml in the project root (see .wails-kit.example.yml)
 #   - yq (https://github.com/mikefarah/yq)
 #   - gh (GitHub CLI)
-#   - Wails-generated platform Taskfiles included at root level as darwin:, linux:, etc.
+#   - Wails-generated platform Taskfiles included at root level as darwin:, linux:, windows:, etc.
 
 version: '3'
 
@@ -36,19 +36,22 @@ vars:
 
 tasks:
   default:
-    summary: Build, sign, and publish a release
+    summary: Build, sign, and publish a release for the current platform
     desc: |
       Builds a production binary, signs it (macOS: codesign + notarize),
       creates an archive, uploads to the Homebrew tap, and updates the cask.
 
       Defaults to the latest GitHub release tag. Override with VERSION=x.y.z.
+      Defaults to the host architecture. Override with TARGET_ARCH=arm64|amd64|universal.
 
       Usage:
         task release
         task release VERSION=0.3.0
+        task release TARGET_ARCH=universal
     vars:
       VERSION:
         sh: gh release view --json tagName -q '.tagName' -R "{{.KIT_GITHUB_REPO}}" 2>/dev/null | sed 's/^v//'
+      TARGET_ARCH: '{{.TARGET_ARCH | default ARCH}}'
     preconditions:
       - sh: test -f .wails-kit.yml
         msg: "Missing .wails-kit.yml — copy from .wails-kit.example.yml and fill in your values."
@@ -59,10 +62,45 @@ tasks:
       - sh: '[ -n "{{.VERSION}}" ]'
         msg: "Could not determine version. Pass it explicitly: task release VERSION=0.3.0"
     cmds:
-      - echo "Releasing {{.KIT_APP_NAME}} v{{.VERSION}} for {{OS}}/{{ARCH}}"
+      - echo "Releasing {{.KIT_APP_NAME}} v{{.VERSION}} for {{OS}}/{{.TARGET_ARCH}}"
       - task: 'release-{{OS}}'
         vars:
           VERSION: '{{.VERSION}}'
+          TARGET_ARCH: '{{.TARGET_ARCH}}'
+
+  all:
+    summary: Build and publish releases for all specified platforms
+    desc: |
+      Builds releases for multiple OS/architecture combinations.
+
+      Set TARGETS to a comma-separated list of os/arch pairs.
+      macOS supports "universal" arch to create a fat binary via lipo.
+
+      Usage:
+        task release:all VERSION=0.3.0 TARGETS=darwin/universal,linux/amd64,linux/arm64,windows/amd64
+    vars:
+      VERSION:
+        sh: gh release view --json tagName -q '.tagName' -R "{{.KIT_GITHUB_REPO}}" 2>/dev/null | sed 's/^v//'
+      TARGETS: 'darwin/universal,linux/amd64,linux/arm64,windows/amd64'
+    preconditions:
+      - sh: test -f .wails-kit.yml
+        msg: "Missing .wails-kit.yml — copy from .wails-kit.example.yml and fill in your values."
+      - sh: command -v yq
+        msg: "yq is required. Install: brew install yq"
+      - sh: command -v gh
+        msg: "GitHub CLI (gh) is required. Install: brew install gh"
+      - sh: '[ -n "{{.VERSION}}" ]'
+        msg: "Could not determine version. Pass it explicitly: task release:all VERSION=0.3.0"
+    cmds:
+      - |
+        IFS=',' read -ra PAIRS <<< "{{.TARGETS}}"
+        for pair in "${PAIRS[@]}"; do
+          os="${pair%%/*}"
+          arch="${pair##*/}"
+          echo ""
+          echo "=== Releasing {{.KIT_APP_NAME}} v{{.VERSION}} for ${os}/${arch} ==="
+          task release:release-${os} VERSION={{.VERSION}} TARGET_ARCH=${arch}
+        done
 
   release-darwin:
     summary: Build, sign, notarize, and publish macOS release
@@ -70,7 +108,22 @@ tasks:
     vars:
       APP_LOWER:
         sh: echo "{{.KIT_APP_NAME}}" | tr '[:upper:]' '[:lower:]'
-      ARCHIVE: '{{.APP_LOWER}}-{{.VERSION}}-darwin-{{ARCH}}.zip'
+      TARGET_ARCH: '{{.TARGET_ARCH | default ARCH}}'
+    cmds:
+      - task: '{{if eq .TARGET_ARCH "universal"}}darwin-universal{{else}}darwin-arch{{end}}'
+        vars:
+          VERSION: '{{.VERSION}}'
+          TARGET_ARCH: '{{.TARGET_ARCH}}'
+
+  darwin-arch:
+    summary: Build macOS release for a single architecture
+    internal: true
+    vars:
+      APP_LOWER:
+        sh: echo "{{.KIT_APP_NAME}}" | tr '[:upper:]' '[:lower:]'
+      ARCHIVE: '{{.APP_LOWER}}-{{.VERSION}}-darwin-{{.TARGET_ARCH}}.zip'
+    env:
+      GOARCH: '{{.TARGET_ARCH}}'
     cmds:
       - task: ':darwin:package'
       - task: sign
@@ -84,6 +137,43 @@ tasks:
         vars:
           VERSION: '{{.VERSION}}'
           ARCHIVE: '{{.ARCHIVE}}'
+          CASK_ARCH: '{{.TARGET_ARCH}}'
+
+  darwin-universal:
+    summary: Build macOS universal binary (arm64 + amd64)
+    internal: true
+    vars:
+      APP_LOWER:
+        sh: echo "{{.KIT_APP_NAME}}" | tr '[:upper:]' '[:lower:]'
+      ARCHIVE: '{{.APP_LOWER}}-{{.VERSION}}-darwin-universal.zip'
+    cmds:
+      # Build arm64
+      - mkdir -p "{{.BIN_DIR}}/arm64" "{{.BIN_DIR}}/amd64"
+      - GOARCH=arm64 task :darwin:package
+      - cp -R "{{.BIN_DIR}}/{{.KIT_APP_NAME}}.app" "{{.BIN_DIR}}/arm64/{{.KIT_APP_NAME}}.app"
+      # Build amd64
+      - GOARCH=amd64 task :darwin:package
+      - cp -R "{{.BIN_DIR}}/{{.KIT_APP_NAME}}.app" "{{.BIN_DIR}}/amd64/{{.KIT_APP_NAME}}.app"
+      # Merge with lipo
+      - |
+        BINARY="Contents/MacOS/{{.KIT_APP_NAME}}"
+        lipo -create \
+          "{{.BIN_DIR}}/arm64/{{.KIT_APP_NAME}}.app/${BINARY}" \
+          "{{.BIN_DIR}}/amd64/{{.KIT_APP_NAME}}.app/${BINARY}" \
+          -output "{{.BIN_DIR}}/{{.KIT_APP_NAME}}.app/${BINARY}"
+      - rm -rf "{{.BIN_DIR}}/arm64" "{{.BIN_DIR}}/amd64"
+      - task: sign
+      - task: notarize
+      - cd "{{.BIN_DIR}}" && zip -r "{{.ARCHIVE}}" "{{.KIT_APP_NAME}}.app"
+      - task: upload
+        vars:
+          VERSION: '{{.VERSION}}'
+          ARCHIVE: '{{.ARCHIVE}}'
+      - task: update-cask
+        vars:
+          VERSION: '{{.VERSION}}'
+          ARCHIVE: '{{.ARCHIVE}}'
+          CASK_ARCH: universal
 
   release-linux:
     summary: Build and publish Linux release
@@ -91,10 +181,31 @@ tasks:
     vars:
       APP_LOWER:
         sh: echo "{{.KIT_APP_NAME}}" | tr '[:upper:]' '[:lower:]'
-      ARCHIVE: '{{.APP_LOWER}}-{{.VERSION}}-linux-{{ARCH}}.tar.gz'
+      TARGET_ARCH: '{{.TARGET_ARCH | default ARCH}}'
+      ARCHIVE: '{{.APP_LOWER}}-{{.VERSION}}-linux-{{.TARGET_ARCH}}.tar.gz'
+    env:
+      GOARCH: '{{.TARGET_ARCH}}'
     cmds:
       - task: ':linux:build'
       - cd "{{.BIN_DIR}}" && tar czf "{{.ARCHIVE}}" "{{.KIT_APP_NAME}}"
+      - task: upload
+        vars:
+          VERSION: '{{.VERSION}}'
+          ARCHIVE: '{{.ARCHIVE}}'
+
+  release-windows:
+    summary: Build and publish Windows release
+    internal: true
+    vars:
+      APP_LOWER:
+        sh: echo "{{.KIT_APP_NAME}}" | tr '[:upper:]' '[:lower:]'
+      TARGET_ARCH: '{{.TARGET_ARCH | default ARCH}}'
+      ARCHIVE: '{{.APP_LOWER}}-{{.VERSION}}-windows-{{.TARGET_ARCH}}.zip'
+    env:
+      GOARCH: '{{.TARGET_ARCH}}'
+    cmds:
+      - task: ':windows:build'
+      - cd "{{.BIN_DIR}}" && zip -r "{{.ARCHIVE}}" "{{.KIT_APP_NAME}}.exe"
       - task: upload
         vars:
           VERSION: '{{.VERSION}}'
@@ -156,6 +267,7 @@ tasks:
         sh: shasum -a 256 "{{.BIN_DIR}}/{{.ARCHIVE}}" | awk '{print $1}'
       APP_LOWER:
         sh: echo "{{.KIT_APP_NAME}}" | tr '[:upper:]' '[:lower:]'
+      CASK_ARCH: '{{.CASK_ARCH | default ARCH}}'
     cmds:
       - |
         # Clone the tap repo, update the cask formula, push
@@ -176,7 +288,7 @@ tasks:
         # Update SHA — detect multi-arch vs single-arch cask
         if grep -q 'arch arm64\|on_arm\|hardware.arch' "$CASK_FILE" 2>/dev/null; then
           # Multi-arch cask: update SHA within the architecture-specific block
-          if [ "{{ARCH}}" = "arm64" ]; then
+          if [ "{{.CASK_ARCH}}" = "arm64" ]; then
             sed -i'' -e '/arm64/,/sha256/{s/sha256 "[^"]*"/sha256 "{{.SHA}}"/;}' "$CASK_FILE"
           else
             sed -i'' -e '/intel/,/sha256/{s/sha256 "[^"]*"/sha256 "{{.SHA}}"/;}' "$CASK_FILE"
@@ -188,7 +300,7 @@ tasks:
 
         cd "$TMPDIR/tap"
         git add -A
-        git commit -m "Update {{.APP_LOWER}} to v{{.VERSION}} ({{ARCH}})"
+        git commit -m "Update {{.APP_LOWER}} to v{{.VERSION}} ({{.CASK_ARCH}})"
         git push
 
         echo "Updated cask {{.APP_LOWER}} to v{{.VERSION}}"

--- a/updates/README.md
+++ b/updates/README.md
@@ -89,6 +89,25 @@ All events are emitted through the `events.Emitter` if one is provided via `With
 | `updates:downloading` | `DownloadingPayload{Version, Progress, Downloaded, Total}` | Download progress (throttled to 250ms) |
 | `updates:ready` | `ReadyPayload{Version}` | Download complete, ready to apply |
 | `updates:error` | `ErrorPayload{Message, Code}` | Any update operation failed |
+| `updates:managed` | `ManagedPayload{Method, Instructions}` | App installed via package manager; self-update blocked |
+
+## Managed install detection
+
+`ApplyUpdate` detects when the app was installed via a package manager and returns an `ErrUpdateManaged` error instead of attempting to replace the binary. An `updates:managed` event is emitted with instructions for the user.
+
+Currently detected:
+- **Homebrew Cask** (macOS) — detects `/usr/local/Caskroom/` and `/opt/homebrew/Caskroom/` paths
+
+The frontend can listen for the `updates:managed` event to show appropriate UI (e.g., "Update via `brew upgrade --cask myapp`" instead of a self-update button).
+
+You can also call `DetectInstallMethod()` directly to check the install method before offering self-update UI at all:
+
+```go
+if method := updates.DetectInstallMethod(); method != updates.InstallDirect {
+    // Show "update via package manager" UI instead of self-update
+    fmt.Println(method.UpdateInstructions("myapp"))
+}
+```
 
 ## Error codes
 
@@ -98,6 +117,7 @@ All events are emitted through the `events.Emitter` if one is provided via `With
 | `update_download` | Failed to download the update. Please try again. |
 | `update_apply` | Failed to install the update. Please try again. |
 | `update_verify` | Update signature verification failed. The download may be corrupted or tampered with. |
+| `update_managed` | This app is managed by a package manager. Please update through your package manager instead. |
 
 ## Signature verification
 

--- a/updates/managed.go
+++ b/updates/managed.go
@@ -1,0 +1,60 @@
+package updates
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// InstallMethod describes how the application was installed.
+type InstallMethod string
+
+const (
+	// InstallDirect means the binary was installed directly (download, go install, etc.).
+	InstallDirect InstallMethod = ""
+	// InstallHomebrew means the binary was installed via Homebrew Cask.
+	InstallHomebrew InstallMethod = "homebrew"
+)
+
+// homebrewPrefixes are the known Homebrew Caskroom paths.
+var homebrewPrefixes = []string{
+	"/usr/local/Caskroom/",
+	"/opt/homebrew/Caskroom/",
+}
+
+// DetectInstallMethod determines how the running binary was installed
+// by inspecting its resolved file path.
+func DetectInstallMethod() InstallMethod {
+	exe, err := os.Executable()
+	if err != nil {
+		return InstallDirect
+	}
+
+	// Resolve symlinks to get the real path
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		resolved = exe
+	}
+
+	if runtime.GOOS == "darwin" {
+		for _, prefix := range homebrewPrefixes {
+			if strings.HasPrefix(resolved, prefix) {
+				return InstallHomebrew
+			}
+		}
+	}
+
+	return InstallDirect
+}
+
+// UpdateInstructions returns a user-facing string explaining how to update
+// for the given install method.
+func (m InstallMethod) UpdateInstructions(appName string) string {
+	switch m {
+	case InstallHomebrew:
+		return "This app was installed via Homebrew. Run: brew upgrade --cask " + appName
+	default:
+		return ""
+	}
+}

--- a/updates/managed_test.go
+++ b/updates/managed_test.go
@@ -1,0 +1,30 @@
+package updates
+
+import "testing"
+
+func TestInstallMethodUpdateInstructions(t *testing.T) {
+	tests := []struct {
+		method InstallMethod
+		app    string
+		want   string
+	}{
+		{InstallDirect, "myapp", ""},
+		{InstallHomebrew, "myapp", "This app was installed via Homebrew. Run: brew upgrade --cask myapp"},
+	}
+
+	for _, tt := range tests {
+		got := tt.method.UpdateInstructions(tt.app)
+		if got != tt.want {
+			t.Errorf("InstallMethod(%q).UpdateInstructions(%q) = %q, want %q", tt.method, tt.app, got, tt.want)
+		}
+	}
+}
+
+func TestDetectInstallMethodDirect(t *testing.T) {
+	// When running tests, the executable is the test binary which
+	// is not inside a Homebrew Caskroom, so it should be direct.
+	method := DetectInstallMethod()
+	if method != InstallDirect {
+		t.Errorf("expected InstallDirect, got %q", method)
+	}
+}

--- a/updates/service.go
+++ b/updates/service.go
@@ -21,6 +21,7 @@ const (
 	EventDownloading = "updates:downloading"
 	EventReady       = "updates:ready"
 	EventError       = "updates:error"
+	EventManaged     = "updates:managed"
 )
 
 // Error codes.
@@ -29,6 +30,7 @@ const (
 	ErrUpdateDownload errors.Code = "update_download"
 	ErrUpdateApply    errors.Code = "update_apply"
 	ErrUpdateVerify   errors.Code = "update_verify"
+	ErrUpdateManaged  errors.Code = "update_managed"
 )
 
 func init() {
@@ -37,6 +39,7 @@ func init() {
 		ErrUpdateDownload: "Failed to download the update. Please try again.",
 		ErrUpdateApply:    "Failed to install the update. Please try again.",
 		ErrUpdateVerify:   "Update signature verification failed. The download may be corrupted or tampered with.",
+		ErrUpdateManaged:  "This app is managed by a package manager. Please update through your package manager instead.",
 	})
 }
 
@@ -62,6 +65,11 @@ type (
 	ErrorPayload struct {
 		Message string      `json:"message"`
 		Code    errors.Code `json:"code"`
+	}
+
+	ManagedPayload struct {
+		Method       InstallMethod `json:"method"`
+		Instructions string        `json:"instructions"`
 	}
 )
 
@@ -326,7 +334,20 @@ func (s *Service) DownloadUpdate(ctx context.Context) (string, error) {
 }
 
 // ApplyUpdate applies a previously downloaded update to the running binary.
+// Returns an ErrUpdateManaged error if the app was installed via a package
+// manager (e.g., Homebrew Cask). In that case, an updates:managed event is
+// emitted with instructions for the user.
 func (s *Service) ApplyUpdate(ctx context.Context) error {
+	// Check for managed installs before attempting anything
+	if method := DetectInstallMethod(); method != InstallDirect {
+		instructions := method.UpdateInstructions(s.appName)
+		s.emit(EventManaged, ManagedPayload{
+			Method:       method,
+			Instructions: instructions,
+		})
+		return errors.Newf(ErrUpdateManaged, "%s", instructions)
+	}
+
 	s.mu.Lock()
 	downloadPath := s.downloadPath
 	s.mu.Unlock()


### PR DESCRIPTION
## Summary

Add comprehensive cross-platform release build support and Homebrew install detection for auto-updates.

**Taskfiles:** Windows, universal macOS (via lipo), and cross-architecture compilation. New `release:all` task for batch builds; `TARGET_ARCH` variable for cross-compilation.

**Updates:** Detect Homebrew Cask installations and block self-update with helpful instructions instead of silent failures.

## Test plan

- [x] All tests pass (lint, Go tests, TypeScript tests)
- [x] Release taskfile YAML validates
- [x] Managed install detection works on non-Homebrew paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)